### PR TITLE
FIx on IDU transformation

### DIFF
--- a/pystac_monty/sources/idu.py
+++ b/pystac_monty/sources/idu.py
@@ -76,6 +76,10 @@ class IDUTransformer(MontyDataTransformer):
         items = []
 
         event_items = self.make_source_event_items()
+        # Get the latest item based on id(the last occurrence)
+        # and get rid of duplicate items at event level
+        event_items_unique = {item.id: item for item in event_items}
+        event_items = list(event_items_unique.values())
         items.extend(event_items)
 
         impact_items = self.make_impact_items()


### PR DESCRIPTION
- Fix the IDU Transformer to use different impact types
- Get only the unique (last occurrence) event items based on the event id.