### PR TITLE
Use the logger warnings instead

### DIFF
--- a/pystac_monty/sources/desinventar.py
+++ b/pystac_monty/sources/desinventar.py
@@ -619,7 +619,7 @@ class DesinventarTransformer(MontyDataTransformer[DesinventarDataSource]):
                             self.transform_summary.increment_failed_rows()
                 except Exception:
                     self.transform_summary.increment_failed_rows()
-                    logger.error("Failed to process desinventar", exc_info=True)
+                    logger.warning("Failed to process DesInventar data", exc_info=True)
             self.transform_summary.mark_as_complete()
 
     # FIXME: This is deprecated

--- a/pystac_monty/sources/emdat.py
+++ b/pystac_monty/sources/emdat.py
@@ -173,7 +173,7 @@ class EMDATTransformer(MontyDataTransformer[EMDATDataSource]):
                         self.transform_summary.increment_failed_rows()
                 except Exception:
                     self.transform_summary.increment_failed_rows()
-                    logger.error("Failed to process emdat", exc_info=True)
+                    logger.warning("Failed to process EM-DAT data", exc_info=True)
             self.transform_summary.mark_as_complete()
 
     def get_stac_items_from_memory(self) -> typing.Generator[Item, None, None]:
@@ -194,7 +194,7 @@ class EMDATTransformer(MontyDataTransformer[EMDATDataSource]):
                     self.transform_summary.increment_failed_rows()
             except Exception:
                 self.transform_summary.increment_failed_rows()
-                logger.error("Failed to process emdat", exc_info=True)
+                logger.warning("Failed to process emdat", exc_info=True)
         self.transform_summary.mark_as_complete()
 
     def make_source_event_item(self, row: EmdatDataValidator) -> Optional[Item]:

--- a/pystac_monty/sources/gfd.py
+++ b/pystac_monty/sources/gfd.py
@@ -106,7 +106,7 @@ class GFDTransformer(MontyDataTransformer[GFDDataSource]):
                     self.transform_summary.increment_failed_rows()
             except Exception:
                 self.transform_summary.increment_failed_rows()
-                logger.error("Failed to process gfd", exc_info=True)
+                logger.warning("Failed to process GFD data", exc_info=True)
         self.transform_summary.mark_as_complete()
 
     def _get_bounding_box(self, polygon: list):

--- a/pystac_monty/sources/gidd.py
+++ b/pystac_monty/sources/gidd.py
@@ -105,7 +105,7 @@ class GIDDTransformer(MontyDataTransformer[GIDDDataSource]):
                     self.transform_summary.increment_failed_rows(len(gidd_data))
             except Exception:
                 self.transform_summary.increment_failed_rows(len(gidd_data))
-                logger.error("Failed to process the GIDD data", exc_info=True)
+                logger.warning("Failed to process the GIDD data", exc_info=True)
         self.transform_summary.mark_as_complete()
 
     # FIXME: This is deprecated

--- a/pystac_monty/sources/glide.py
+++ b/pystac_monty/sources/glide.py
@@ -106,7 +106,7 @@ class GlideTransformer(MontyDataTransformer[GlideDataSource]):
                         self.transform_summary.increment_failed_rows()
                 except Exception:
                     self.transform_summary.increment_failed_rows()
-                    logger.error("Failed to process glide", exc_info=True)
+                    logger.warning("Failed to process Glide data", exc_info=True)
             self.transform_summary.mark_as_complete()
 
     def get_stac_items_from_memory(self) -> typing.Generator[Item, None, None]:
@@ -129,7 +129,7 @@ class GlideTransformer(MontyDataTransformer[GlideDataSource]):
                     self.transform_summary.increment_failed_rows()
             except Exception:
                 self.transform_summary.increment_failed_rows()
-                logger.error("Failed to process glide", exc_info=True)
+                logger.warning("Failed to process Glide data", exc_info=True)
         self.transform_summary.mark_as_complete()
 
     def get_hazard_codes(self, hazard: str) -> List[str]:

--- a/pystac_monty/sources/ibtracs.py
+++ b/pystac_monty/sources/ibtracs.py
@@ -141,7 +141,7 @@ class IBTrACSTransformer(MontyDataTransformer[IBTrACSDataSource]):
                     self.transform_summary.increment_failed_rows(len(storm_data))
             except Exception:
                 self.transform_summary.increment_failed_rows(len(storm_data))
-                logger.error("Failed to process ibtracs", exc_info=True)
+                logger.warning("Failed to process IBTrACS data", exc_info=True)
         self.transform_summary.mark_as_complete()
 
     # FIXME: This is deprecated
@@ -640,7 +640,7 @@ class IBTrACSTransformer(MontyDataTransformer[IBTrACSDataSource]):
                     countries.append(country_code)
         except Exception as e:
             # If geocoding fails, default to international waters
-            logger.error(f"Geocoding error: {e}", exc_info=True)
+            logger.warning(f"Geocoding error: {e}", exc_info=True)
             # FIXME: Should we use ["UNK"] instead?
             return ["XYZ"]
 

--- a/pystac_monty/sources/idu.py
+++ b/pystac_monty/sources/idu.py
@@ -104,7 +104,7 @@ class IDUTransformer(MontyDataTransformer[IDUDataSource]):
                     self.transform_summary.increment_failed_rows(len(idu_data))
             except Exception:
                 self.transform_summary.increment_failed_rows(len(idu_data))
-                logger.error("Failed to process the IDU data", exc_info=True)
+                logger.warning("Failed to process the IDU data", exc_info=True)
         self.transform_summary.mark_as_complete()
 
     # FIXME: This is deprecated
@@ -236,7 +236,9 @@ class IDUTransformer(MontyDataTransformer[IDUDataSource]):
 
                     for item in items:
                         if item["displacement_type"] not in IDMCUtils.DisplacementType._value2member_map_:
-                            logging.error(f"Unknown displacement type: {item['displacement_type']} found. Ignore the datapoint.")
+                            logging.warning(
+                                f"Unknown displacement type: {item['displacement_type']} found. Ignore the datapoint."
+                            )
                             continue
                         # Get the Disaster type data only
                         if IDMCUtils.DisplacementType(item["displacement_type"]) == IDMCUtils.DisplacementType.DISASTER_TYPE:

--- a/pystac_monty/sources/ifrc_events.py
+++ b/pystac_monty/sources/ifrc_events.py
@@ -99,7 +99,7 @@ class IFRCEventTransformer(MontyDataTransformer[IFRCEventDataSource]):
                         self.transform_summary.increment_failed_rows()
                 except Exception:
                     self.transform_summary.increment_failed_rows()
-                    logger.error("Failed to process ifrc events", exc_info=True)
+                    logger.warning("Failed to process IFRC events data", exc_info=True)
             self.transform_summary.mark_as_complete()
 
     def get_stac_items_from_memory(self) -> typing.Generator[Item, None, None]:
@@ -135,7 +135,7 @@ class IFRCEventTransformer(MontyDataTransformer[IFRCEventDataSource]):
                     self.transform_summary.increment_failed_rows()
             except Exception:
                 self.transform_summary.increment_failed_rows()
-                logger.error("Failed to process ifrc events", exc_info=True)
+                logger.warning("Failed to process IFRC events data", exc_info=True)
         self.transform_summary.mark_as_complete()
 
     def get_stac_items(self) -> typing.Generator[Item, None, None]:

--- a/pystac_monty/sources/pdc.py
+++ b/pystac_monty/sources/pdc.py
@@ -180,7 +180,7 @@ class PDCTransformer(MontyDataTransformer):
                     self.transform_summary.increment_failed_rows()
             except Exception:
                 self.transform_summary.increment_failed_rows()
-                logger.error("Failed to process pdc", exc_info=True)
+                logger.warning("Failed to process PDC data", exc_info=True)
         self.transform_summary.mark_as_complete()
 
     def make_source_event_item(self, pdc_hazard_data: HazardEventValidator, pdc_exposure_data: ExposureDetailValidator):

--- a/pystac_monty/sources/usgs.py
+++ b/pystac_monty/sources/usgs.py
@@ -394,7 +394,7 @@ class USGSTransformer(MontyDataTransformer[USGSDataSource]):
                 self.transform_summary.increment_failed_rows(1)
         except Exception:
             self.transform_summary.increment_failed_rows(1)
-            logger.error("Failed to process the USGS data.", exc_info=True)
+            logger.warning("Failed to process the USGS data.", exc_info=True)
 
         self.transform_summary.mark_as_complete()
 

--- a/pystac_monty/validators/gidd.py
+++ b/pystac_monty/validators/gidd.py
@@ -62,7 +62,7 @@ class Properties(BaseModelWithExtra):
     @field_validator("Figure_cause")
     def check_figure_cause(cls, value: str) -> str | None:
         if value not in ["Conflict", "Disaster", "Other"]:
-            logger.error("Figure cause must be either 'Conflict' or 'Disaster'.")
+            logger.warning("Figure cause must be either 'Conflict' or 'Disaster'.")
             return None
         return value
 

--- a/pystac_monty/validators/ibtracs.py
+++ b/pystac_monty/validators/ibtracs.py
@@ -35,7 +35,7 @@ class IBTracsdataValidator(BaseModelWithExtra):
     def validate_basin(cls, value: str):
         if value not in ["NA", "SA", "EP", "SP", "WP", "SI", "NI"]:
             # FIXME: Add log extra
-            logger.error("Invalid basin code.")
+            logger.warning("Invalid basin code.")
             return False
         return value
 
@@ -43,6 +43,6 @@ class IBTracsdataValidator(BaseModelWithExtra):
     def validate_sid(cls, value: str):
         if value == " ":
             # FIXME: Add log extra
-            logger.error("Invalid SID")
+            logger.warning("Invalid SID")
             return False
         return value

--- a/pystac_monty/validators/idu.py
+++ b/pystac_monty/validators/idu.py
@@ -48,7 +48,7 @@ class IDUSourceValidator(BaseModelWithExtra):
     def validate_latitude(cls, value: float) -> float | None:
         """Validation for Latitude field"""
         if not (-90 <= value <= 90):
-            logger.error("Latitude must be between -90 and 90.")
+            logger.warning("Latitude must be between -90 and 90.")
             return None
         return value
 
@@ -57,7 +57,7 @@ class IDUSourceValidator(BaseModelWithExtra):
     def validate_longitude(cls, value: float) -> float | None:
         """Validation for Longitude field"""
         if not (-180 <= value <= 180):
-            logger.error("Longitude must be between -180 and 180.")
+            logger.warning("Longitude must be between -180 and 180.")
             return None
         return value
 
@@ -68,14 +68,14 @@ class IDUSourceValidator(BaseModelWithExtra):
         try:
             coords = json.loads(value)  # Parse JSON format list
             if not isinstance(coords, list) or len(coords) != 2:
-                logger.error("Centroid must be a list with two values: [latitude, longitude].")
+                logger.warning("Centroid must be a list with two values: [latitude, longitude].")
                 return None
             latitude, longitude = coords
             if not (-90 <= latitude <= 90) or not (-180 <= longitude <= 180):
-                logger.error("Invalid centroid coordinates.")
+                logger.warning("Invalid centroid coordinates.")
                 return None
         except (json.JSONDecodeError, ValueError):
-            logger.error("Invalid centroid format. Must be a JSON string representing [latitude, longitude].")
+            logger.warning("Invalid centroid format. Must be a JSON string representing [latitude, longitude].")
             return None
         return value
 
@@ -86,7 +86,7 @@ class IDUSourceValidator(BaseModelWithExtra):
     def validate_date(cls, value: date) -> date | None:
         """Validation for date field"""
         if not isinstance(value, date):
-            logger.error(f"Invalid date format: {value}. Expected YYYY-MM-DD.")
+            logger.warning(f"Invalid date format: {value}. Expected YYYY-MM-DD.")
             return None
         return value
 
@@ -96,6 +96,6 @@ class IDUSourceValidator(BaseModelWithExtra):
         """Validation for source_url field"""
         url_regex = r"^(https?://)?([a-zA-Z0-9_-]+(\.[a-zA-Z0-9_-]+)+)(/[^\s]*)?$"
         if not re.match(url_regex, value):
-            logger.error(f"Invalid URL: {value}")
+            logger.warning(f"Invalid URL: {value}")
             return None
         return value

--- a/pystac_monty/validators/ifrc.py
+++ b/pystac_monty/validators/ifrc.py
@@ -117,6 +117,6 @@ class IFRCsourceValidator(BaseModel):
     def validate_countries(cls, value: list) -> list | None:
         """Validate whether the countries field is a empty list"""
         if not value:
-            logger.error("Empty country list.")
+            logger.warning("Empty country list.")
             return None
         return value

--- a/pystac_monty/validators/usgs.py
+++ b/pystac_monty/validators/usgs.py
@@ -56,7 +56,7 @@ class Geometry(BaseModel):
     @field_validator("coordinates")
     def validate_coordinates(cls, value):
         if len(value) != 3:
-            logger.error("Coordinates must have exactly three elements (longitude, latitude, depth)")
+            logger.warning("Coordinates must have exactly three elements (longitude, latitude, depth)")
         return value
 
 


### PR DESCRIPTION
- Use the warnings instead of error to avoid overflow of errors in sentry.