### PR TITLE
Fix/ibtracs links

### DIFF
--- a/pystac_monty/sources/ibtracs.py
+++ b/pystac_monty/sources/ibtracs.py
@@ -575,7 +575,7 @@ class IBTrACSTransformer(MontyDataTransformer[IBTrACSDataSource]):
                     rel="related",
                     target=f"../ibtracs-events/{storm_id}.json",
                     media_type="application/json",
-                    extra_fields={"roles": ["event", "source"]},
+                    extra_fields={"roles": ["event"]},
                 )
             )
 

--- a/tests/extensions/test_ibtracs.py
+++ b/tests/extensions/test_ibtracs.py
@@ -450,7 +450,9 @@ class IBTrACSTest(unittest.TestCase):
             # Check that related link points to event
             event_link = next((link for link in related_links if "event" in link.extra_fields.get("roles", [])), None)
             self.assertIsNotNone(event_link)
-            self.assertIn("source", event_link.extra_fields.get("roles", []))
+            self.assertIn(
+                "event", event_link.extra_fields.get("roles", [])
+            )  # Hazard item has related item of corresponding event
 
         # Verify Related links exists
         if event_items and hazard_items:


### PR DESCRIPTION
- Use only valid role type in the links property based on schema.