### PR TITLE
feat: add file exporter.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## [Unreleased]
 
+### Added
 
+- Static Monty STAC batch export (`pystac_monty/exporter.py`) with role subcatalogs on disk.
+- CLI entrypoint `pystac-monty` for GLIDE, GFD, and GDACS sources (`pystac_monty/sources/batch_export.py`).
+- `ItemMontyExtension.is_source_response()` for partitioning response items.
 
 [Unreleased]: <https://github.com/stac-utils/pystac/compare/v1.11.0..main>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ### Added
 
-- Static Monty STAC batch export (`pystac_monty/exporter.py`) with role subcatalogs on disk.
-- CLI entrypoint `pystac-monty` for GLIDE, GFD, and GDACS sources (`pystac_monty/sources/batch_export.py`).
+- Static Monty STAC batch export (`pystac_monty/exporter.py`) with role collections on disk.
+- CLI entrypoint `pystac-monty` for GLIDE, GFD, and GDACS sources (`pystac_monty/sources/batch_export.py`). GDACS accepts a native `GdacsDataSourceType` bundle JSON produced upstream (e.g. montandon-etl).
 - `ItemMontyExtension.is_source_response()` for partitioning response items.
 
 [Unreleased]: <https://github.com/stac-utils/pystac/compare/v1.11.0..main>

--- a/README.md
+++ b/README.md
@@ -38,7 +38,25 @@ jq --version
 
 ## Usage
 
-## Extending a STAC Item
+### Batch export (CLI)
+
+To export upstream source files to on-disk Monty STAC, first initialise the submodule:
+
+```sh
+git submodule update --init --recursive
+```
+
+Then run the CLI. `SOURCE` is one of `glide`, `gfd`, `gdacs`; `--input` accepts a source-specific file (see the `convert_*` docstrings in `pystac_monty/sources/batch_export.py`):
+
+```sh
+pystac-monty SOURCE --input path/to/input --output path/to/output/
+```
+
+The output directory will contain role subcatalogs (`{slug}-events/`, `{slug}-hazards/`, etc.), each with a collection JSON and flat item files. Raw source payloads live in `monty-stac-extension/docs/model/sources/` — the `examples/` folders are published STAC output, not inputs.
+
+To add more sources or use the exporter programmatically, see `pystac_monty/exporter.py`.
+
+### Extending a STAC Item
 
 The library provides classes and functions to work with Montandon STAC objects. Here is an example of how to create a Montandon Item:
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Then run the CLI. `SOURCE` is one of `glide`, `gfd`, `gdacs`; `--input` accepts 
 pystac-monty SOURCE --input path/to/input --output path/to/output/
 ```
 
-The output directory will contain role subcatalogs (`{slug}-events/`, `{slug}-hazards/`, etc.), each with a collection JSON and flat item files. Raw source payloads live in `monty-stac-extension/docs/model/sources/` — the `examples/` folders are published STAC output, not inputs.
+The output directory will contain role collections (`{slug}-events/`, `{slug}-hazards/`, etc.), each with a collection JSON and flat item files. Raw source payloads live in `monty-stac-extension/docs/model/sources/` — the `examples/` folders are published STAC output, not inputs.
 
 To add more sources or use the exporter programmatically, see `pystac_monty/exporter.py`.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,9 @@ Issues = "https://github.com/IFRCGo/monty-stac-extension/issues"
 Changelog = "https://github.com/IFRCGo/monty-stac-extension/blob/main/CHANGELOG.md"
 Discussions = "https://github.com/radiantearth/stac-spec/discussions/categories/stac-software"
 
+[project.scripts]
+pystac-monty = "pystac_monty.cli:main"
+
 [tool.coverage.run]
 branch = true
 source = ["pystac_monty"]

--- a/pystac_monty/cli.py
+++ b/pystac_monty/cli.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""CLI: batch export of Monty STAC to a directory tree."""
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+from pystac_monty.sources.batch_export import BATCH_EXPORTS, run_batch
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    if not BATCH_EXPORTS:
+        print(
+            "No batch sources registered. Use export_collected_items() from pystac_monty.exporter.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    parser = argparse.ArgumentParser(description="Convert local source inputs to on-disk STAC (Monty).")
+    parser.add_argument("source", choices=sorted(BATCH_EXPORTS), metavar="SOURCE")
+    parser.add_argument(
+        "-i",
+        "--input",
+        type=Path,
+        required=True,
+        help="Source-specific input path (see the source convert_* docstring)",
+    )
+    parser.add_argument("-o", "--output", type=Path, required=True, help="Output directory for STAC JSON")
+    args = parser.parse_args()
+    run_batch(args.source, args.input, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/pystac_monty/exporter.py
+++ b/pystac_monty/exporter.py
@@ -238,7 +238,9 @@ def save_static_monty_collection(
 
 
 @dataclass(frozen=True)
-class MontySubcatalog:
+class MontyCollectionSpec:
+    """Inputs for writing one Monty source :class:`pystac.Collection` and its items."""
+
     out_dir: Path
     collection_id: str
     title: str
@@ -251,7 +253,7 @@ class MontySubcatalog:
     public_href_base: str | None = None
 
 
-def export_monty_subcatalog(spec: MontySubcatalog) -> None:
+def export_monty_collection(spec: MontyCollectionSpec) -> None:
     if spec.items:
         collection = build_monty_static_collection(
             spec.items,
@@ -284,16 +286,16 @@ def _role_titles(source_slug: str, overrides: dict[MontyRole, tuple[str, str]] |
     return {**defaults, **(overrides or {})}
 
 
-def _subcatalog_spec(
+def _collection_spec(
     config: BatchExportConfig,
     output_root: Path,
     role: MontyRole,
     items: list[Item],
     collection_id: str,
     titles: dict[MontyRole, tuple[str, str]],
-) -> MontySubcatalog:
+) -> MontyCollectionSpec:
     title, description = titles[role]
-    return MontySubcatalog(
+    return MontyCollectionSpec(
         out_dir=output_root / collection_id,
         collection_id=collection_id,
         title=title,
@@ -327,10 +329,10 @@ def export_collected_items(
             continue
         if role == "response":
             wrote_response = True
-        export_monty_subcatalog(_subcatalog_spec(config, output_root, role, list(role_items), collection_id, titles))
-    if config.emit_empty_response_subcatalog and not wrote_response:
+        export_monty_collection(_collection_spec(config, output_root, role, list(role_items), collection_id, titles))
+    if config.emit_empty_response_collection and not wrote_response:
         collection_id = f"{config.source_slug}-response"
-        export_monty_subcatalog(_subcatalog_spec(config, output_root, "response", [], collection_id, titles))
+        export_monty_collection(_collection_spec(config, output_root, "response", [], collection_id, titles))
     return len(events), len(hazards), len(impacts), len(responses)
 
 
@@ -342,7 +344,7 @@ class BatchExportConfig:
     provider: Provider
     titles: dict[MontyRole, tuple[str, str]] | None = None
     preserve_transformer_item_links: bool = True
-    emit_empty_response_subcatalog: bool = False
+    emit_empty_response_collection: bool = False
     omit_keywords_from_summaries: bool = False
     public_href_base: str | None = None
 

--- a/pystac_monty/exporter.py
+++ b/pystac_monty/exporter.py
@@ -1,0 +1,357 @@
+"""Static Monty STAC on disk and batch export helpers.
+
+Write :class:`pystac.Collection` JSON and sidecar :class:`pystac.Item` files from items
+returned by :meth:`~pystac_monty.sources.common.MontyDataTransformer.get_stac_items`.
+Per-source ingestion (globs, CSV, APIs) lives in ``sources/<name>.py``.
+
+Item bodies match PySTAC ``save_object`` / :meth:`pystac.Item.to_dict`. Catalog hierarchy
+links are stripped from items; ``collection_id`` is kept.
+
+CLI batch sources register in :mod:`pystac_monty.sources.batch_export` as ``convert_<name>``
+functions mapped by :data:`~pystac_monty.sources.batch_export.BATCH_EXPORTS`.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Literal, Optional, Sequence, cast
+
+import pystac
+from pystac import Item
+from pystac.provider import Provider
+from pystac.summaries import RangeSummary, Summaries, Summarizer, SummaryStrategy
+from pystac.utils import datetime_to_str
+
+from pystac_monty.extension import SCHEMA_URI, ItemMontyExtension, MontyExtension
+
+logger = logging.getLogger(__name__)
+
+MONTY_STAC_EXAMPLES_BASE_URL = "https://ifrcgo.org/monty-stac-extension/examples"
+
+MONTY_STATIC_SUMMARY_FIELDS: dict[str, SummaryStrategy] = {
+    "monty:country_codes": SummaryStrategy.ARRAY,
+    "monty:hazard_codes": SummaryStrategy.ARRAY,
+    "keywords": SummaryStrategy.ARRAY,
+}
+_MONTY_SUMMARY_SORT_KEYS: tuple[str, ...] = ("monty:country_codes", "monty:hazard_codes", "keywords")
+_SPATIAL_WORLD = pystac.SpatialExtent([[-180.0, -90.0, 180.0, 90.0]])
+_WORLD_EXTENT = pystac.Extent(
+    spatial=_SPATIAL_WORLD,
+    temporal=pystac.TemporalExtent(cast(list[list[Optional[datetime]]], [[None, None]])),
+)
+
+MontyRole = Literal["event", "hazard", "impact", "response"]
+_DEFAULT_ROLE_TITLES: dict[MontyRole, tuple[str, str]] = {
+    "event": ("{slug} source events", "Monty source event items"),
+    "hazard": ("{slug} source hazards", "Monty source hazard items"),
+    "impact": ("{slug} source impacts", "Monty source impact items"),
+    "response": ("{slug} source response", "Monty source response items"),
+}
+
+
+def extent_for_monty_static_collection(items: list[Item]) -> pystac.Extent:
+    if not items:
+        return _WORLD_EXTENT
+    if not any(item.bbox is not None for item in items):
+        return pystac.Extent(spatial=_SPATIAL_WORLD, temporal=pystac.Extent.from_items(items).temporal)
+    extent = pystac.Extent.from_items(items)
+    bbox = extent.spatial.bboxes[0]
+    if not all(math.isfinite(float(x)) for x in bbox):
+        return _WORLD_EXTENT
+    return extent
+
+
+def summaries_for_monty_static_collection(
+    items: list[Item],
+    role: MontyRole,
+    *,
+    include_keywords: bool = True,
+) -> Summaries:
+    fields = (
+        MONTY_STATIC_SUMMARY_FIELDS
+        if include_keywords
+        else {k: v for k, v in MONTY_STATIC_SUMMARY_FIELDS.items() if k != "keywords"}
+    )
+    summaries = Summarizer(fields).summarize(items)
+    summaries.add("roles", [role, "source"])
+    for key in _MONTY_SUMMARY_SORT_KEYS:
+        if values := summaries.get_list(key):
+            summaries.remove(key)
+            summaries.add(key, sorted(values))
+    datetimes: list[str] = []
+    for item in items:
+        if item.datetime is not None:
+            datetimes.append(datetime_to_str(item.datetime))
+        elif item.properties.get("datetime") is not None:
+            value = item.properties["datetime"]
+            datetimes.append(value if isinstance(value, str) else datetime_to_str(value))
+    if datetimes:
+        summaries.add("datetime", RangeSummary(min(datetimes), max(datetimes)))
+    return summaries
+
+
+def partition_monty_source_items(
+    items: Sequence[Item],
+) -> tuple[list[Item], list[Item], list[Item], list[Item]]:
+    """Event / hazard / impact / response lists (Monty *source* roles)."""
+    events: list[Item] = []
+    hazards: list[Item] = []
+    impacts: list[Item] = []
+    responses: list[Item] = []
+    for item in items:
+        monty = cast(ItemMontyExtension, MontyExtension.ext(item))
+        if monty.is_source_event():
+            events.append(item)
+        elif monty.is_source_hazard():
+            hazards.append(item)
+        elif monty.is_source_response():
+            responses.append(item)
+        elif monty.is_source_impact():
+            impacts.append(item)
+    return events, hazards, impacts, responses
+
+
+def _strip_stac_hierarchy_for_static_item(item: Item) -> None:
+    """Drop catalog layout links only; keep :attr:`~pystac.Item.collection_id`."""
+    for rel in (
+        pystac.RelType.SELF,
+        pystac.RelType.PARENT,
+        pystac.RelType.ROOT,
+        pystac.RelType.COLLECTION,
+    ):
+        item.remove_links(rel)
+
+
+def build_monty_static_collection(
+    items: list[Item],
+    *,
+    collection_id: str,
+    title: str,
+    description: str,
+    role: MontyRole,
+    provider: Provider,
+    omit_keywords_from_summaries: bool = False,
+) -> pystac.Collection:
+    keywords = sorted({kw for item in items for kw in (item.properties.get("keywords") or [])})
+    summaries = summaries_for_monty_static_collection(items, role, include_keywords=not omit_keywords_from_summaries)
+    return pystac.Collection(
+        id=collection_id,
+        title=title,
+        description=description,
+        license="proprietary",
+        extent=extent_for_monty_static_collection(items),
+        stac_extensions=[SCHEMA_URI],
+        providers=[provider],
+        summaries=summaries,
+        extra_fields={"roles": [role, "source"], "keywords": keywords},
+        catalog_type=pystac.CatalogType.RELATIVE_PUBLISHED,
+    )
+
+
+def build_empty_static_source_collection(
+    *,
+    collection_id: str,
+    title: str,
+    description: str,
+    role: MontyRole,
+    provider: Provider,
+) -> pystac.Collection:
+    """Empty collection without the Monty extension (no items → required summary fields absent)."""
+    summaries = Summaries(summaries={"roles": [role, "source"]})
+    return pystac.Collection(
+        id=collection_id,
+        title=title,
+        description=description,
+        license="proprietary",
+        extent=_WORLD_EXTENT,
+        stac_extensions=[],
+        providers=[provider],
+        summaries=summaries,
+        extra_fields={"roles": [role, "source"], "keywords": []},
+        catalog_type=pystac.CatalogType.RELATIVE_PUBLISHED,
+    )
+
+
+def _published_example_href(base: str, collection_id: str, name: str) -> str:
+    return f"{base.rstrip('/')}/{collection_id}/{name}"
+
+
+def _json_link(rel: str, href: str) -> dict[str, str]:
+    return {"rel": rel, "href": href, "type": "application/json"}
+
+
+def save_static_monty_collection(
+    collection: pystac.Collection,
+    items: Sequence[Item],
+    dest_dir: Path,
+    *,
+    preserve_transformer_item_links: bool = True,
+    public_href_base: str | None = None,
+) -> None:
+    """Write collection + items; each item JSON matches :meth:`pystac.Item.to_dict`."""
+    out_dir = dest_dir.resolve()
+    out_dir.mkdir(parents=True, exist_ok=True)
+    collection_file = out_dir / f"{collection.id}.json"
+    ordered = sorted(items, key=lambda item: item.id)
+    stac_io = pystac.StacIO.default()
+
+    for item in ordered:
+        if preserve_transformer_item_links:
+            _strip_stac_hierarchy_for_static_item(item)
+        else:
+            item.clear_links()
+        item.collection_id = collection.id
+        item_doc = item.to_dict(include_self_link=False, transform_hrefs=False)
+        transformer_links = item_doc.get("links", [])
+        if public_href_base:
+            self_href = _published_example_href(public_href_base, collection.id, f"{item.id}.json")
+            coll_href = _published_example_href(public_href_base, collection.id, f"{collection.id}.json")
+            item_doc["links"] = [
+                *transformer_links,
+                _json_link("self", self_href),
+                _json_link("collection", coll_href),
+            ]
+        else:
+            # Static on-disk layout: collection property only; no collection link (see test_exporter).
+            item_doc["links"] = [
+                *transformer_links,
+                _json_link("self", f"./{item.id}.json"),
+            ]
+        stac_io.save_json(str(out_dir / f"{item.id}.json"), item_doc)
+
+    collection_doc = collection.to_dict(include_self_link=False, transform_hrefs=False)
+    collection_self = (
+        _published_example_href(public_href_base, collection.id, f"{collection.id}.json")
+        if public_href_base
+        else f"./{collection.id}.json"
+    )
+    collection_doc["links"] = [_json_link("item", f"./{item.id}.json") for item in ordered] + [
+        _json_link("self", collection_self)
+    ]
+    if not collection.stac_extensions and "stac_extensions" not in collection_doc:
+        collection_doc["stac_extensions"] = []
+    stac_io.save_json(str(collection_file), collection_doc)
+
+
+@dataclass(frozen=True)
+class MontySubcatalog:
+    out_dir: Path
+    collection_id: str
+    title: str
+    description: str
+    role: MontyRole
+    items: list[Item]
+    provider: Provider
+    preserve_transformer_item_links: bool = True
+    omit_keywords_from_summaries: bool = False
+    public_href_base: str | None = None
+
+
+def export_monty_subcatalog(spec: MontySubcatalog) -> None:
+    if spec.items:
+        collection = build_monty_static_collection(
+            spec.items,
+            collection_id=spec.collection_id,
+            title=spec.title,
+            description=spec.description,
+            role=spec.role,
+            provider=spec.provider,
+            omit_keywords_from_summaries=spec.omit_keywords_from_summaries,
+        )
+    else:
+        collection = build_empty_static_source_collection(
+            collection_id=spec.collection_id,
+            title=spec.title,
+            description=spec.description,
+            role=spec.role,
+            provider=spec.provider,
+        )
+    save_static_monty_collection(
+        collection,
+        spec.items,
+        spec.out_dir,
+        preserve_transformer_item_links=spec.preserve_transformer_item_links,
+        public_href_base=spec.public_href_base,
+    )
+
+
+def _role_titles(source_slug: str, overrides: dict[MontyRole, tuple[str, str]] | None) -> dict[MontyRole, tuple[str, str]]:
+    defaults = {role: (title.format(slug=source_slug), desc) for role, (title, desc) in _DEFAULT_ROLE_TITLES.items()}
+    return {**defaults, **(overrides or {})}
+
+
+def _subcatalog_spec(
+    config: BatchExportConfig,
+    output_root: Path,
+    role: MontyRole,
+    items: list[Item],
+    collection_id: str,
+    titles: dict[MontyRole, tuple[str, str]],
+) -> MontySubcatalog:
+    title, description = titles[role]
+    return MontySubcatalog(
+        out_dir=output_root / collection_id,
+        collection_id=collection_id,
+        title=title,
+        description=description,
+        role=role,
+        items=items,
+        provider=config.provider,
+        preserve_transformer_item_links=config.preserve_transformer_item_links,
+        omit_keywords_from_summaries=config.omit_keywords_from_summaries,
+        public_href_base=config.public_href_base,
+    )
+
+
+def export_collected_items(
+    config: BatchExportConfig,
+    items: Sequence[Item],
+    output_root: Path,
+) -> tuple[int, int, int, int]:
+    """Partition *items* by Monty role and write ``{source_slug}-events|hazards|impacts|response`` folders."""
+    events, hazards, impacts, responses = partition_monty_source_items(items)
+    titles = _role_titles(config.source_slug, config.titles)
+    blocks: list[tuple[MontyRole, list[Item], str]] = [
+        ("event", events, f"{config.source_slug}-events"),
+        ("hazard", hazards, f"{config.source_slug}-hazards"),
+        ("impact", impacts, f"{config.source_slug}-impacts"),
+        ("response", responses, f"{config.source_slug}-response"),
+    ]
+    wrote_response = False
+    for role, role_items, collection_id in blocks:
+        if not role_items:
+            continue
+        if role == "response":
+            wrote_response = True
+        export_monty_subcatalog(_subcatalog_spec(config, output_root, role, list(role_items), collection_id, titles))
+    if config.emit_empty_response_subcatalog and not wrote_response:
+        collection_id = f"{config.source_slug}-response"
+        export_monty_subcatalog(_subcatalog_spec(config, output_root, "response", [], collection_id, titles))
+    return len(events), len(hazards), len(impacts), len(responses)
+
+
+@dataclass(frozen=True)
+class BatchExportConfig:
+    """Shared metadata for :func:`export_collected_items`."""
+
+    source_slug: str
+    provider: Provider
+    titles: dict[MontyRole, tuple[str, str]] | None = None
+    preserve_transformer_item_links: bool = True
+    emit_empty_response_subcatalog: bool = False
+    omit_keywords_from_summaries: bool = False
+    public_href_base: str | None = None
+
+
+def log_batch_role_counts(events: int, hazards: int, impacts: int, responses: int = 0) -> None:
+    logger.info(
+        "Created %d events, %d hazards, %d impacts, %d response",
+        events,
+        hazards,
+        impacts,
+        responses,
+    )

--- a/pystac_monty/extension.py
+++ b/pystac_monty/extension.py
@@ -660,6 +660,10 @@ class ItemMontyExtension(MontyExtension[pystac.Item]):
         """Indicates if the item is a source impact."""
         return MontyRoles.SOURCE in self.item.properties["roles"] and MontyRoles.IMPACT in self.item.properties["roles"]
 
+    def is_source_response(self) -> bool:
+        """Indicates if the item is a source response."""
+        return MontyRoles.SOURCE in self.item.properties["roles"] and MontyRoles.RESPONSE in self.item.properties["roles"]
+
     def __repr__(self) -> str:
         return f"<ItemMontyExtension Item id={self.item.id}>"
 

--- a/pystac_monty/sources/batch_export.py
+++ b/pystac_monty/sources/batch_export.py
@@ -1,0 +1,166 @@
+"""Run existing Monty transformers and write static STAC via :mod:`pystac_monty.exporter`."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from pystac import Item
+from pystac.provider import Provider, ProviderRole
+
+from pystac_monty.exporter import BatchExportConfig, export_collected_items, log_batch_role_counts
+from pystac_monty.geocoding import MockGeocoder, MontyGeoCoder
+from pystac_monty.sources.common import (
+    DataType,
+    File,
+    GdacsDataSourceType,
+    GdacsEpisodes,
+    GenericDataSource,
+    MontyDataTransformer,
+)
+
+_GDACS_EVENT = "geteventdata"
+_GDACS_GEOMETRY = "getgeometry"
+_GDACS_IMPACT = "getimpact"
+
+
+def file_generic_data_source(input_path: Path, source_url: str | None = None) -> GenericDataSource:
+    path = input_path.resolve()
+    return GenericDataSource(
+        source_url=source_url or path.as_uri(),
+        input_data=File(path=str(path), data_type=DataType.FILE),
+    )
+
+
+def use_local_collection_examples() -> None:
+    examples = Path(__file__).resolve().parents[2] / "monty-stac-extension" / "examples"
+    if examples.is_dir():
+        MontyDataTransformer.base_collection_url = str(examples)
+
+
+def default_batch_geocoder() -> MontyGeoCoder:
+    """Test-oriented geocoder; swap for a real :class:`~pystac_monty.geocoding.MontyGeoCoder` in production."""
+    return MockGeocoder()
+
+
+def collect_transformer_items(transformer: MontyDataTransformer[Any]) -> list[Item]:
+    use_local_collection_examples()
+    return list(transformer.get_stac_items())
+
+
+def export_transformer_items(
+    *,
+    items: list[Item],
+    source_slug: str,
+    provider: Provider,
+    output_dir: Path,
+    emit_empty_response_subcatalog: bool = False,
+) -> tuple[int, int, int, int]:
+    config = BatchExportConfig(
+        source_slug=source_slug,
+        provider=provider,
+        emit_empty_response_subcatalog=emit_empty_response_subcatalog,
+    )
+    counts = export_collected_items(config, items, output_dir)
+    log_batch_role_counts(*counts)
+    return counts
+
+
+def iter_glide_stac_items(input_path: Path) -> list[Item]:
+    from pystac_monty.sources.glide import GlideDataSource, GlideTransformer
+
+    data_source = GlideDataSource(data=file_generic_data_source(input_path))
+    return collect_transformer_items(GlideTransformer(data_source, default_batch_geocoder()))
+
+
+def convert_glide(input_path: Path, output_dir: Path) -> None:
+    """Export GLIDE data. *input_path*: GLIDE ``jsonglideset`` API JSON file."""
+    export_transformer_items(
+        items=iter_glide_stac_items(input_path),
+        source_slug="glide",
+        provider=Provider(name="GLIDE", roles=[ProviderRole.PRODUCER], url="https://www.glidenumber.net/"),
+        output_dir=output_dir,
+    )
+
+
+def iter_gfd_stac_items(input_path: Path) -> list[Item]:
+    from pystac_monty.sources.gfd import GFDDataSource, GFDTransformer
+
+    data_source = GFDDataSource(data=file_generic_data_source(input_path))
+    return collect_transformer_items(GFDTransformer(data_source, default_batch_geocoder()))
+
+
+def convert_gfd(input_path: Path, output_dir: Path) -> None:
+    """Export Global Flood Database data. *input_path*: JSON array of GFD event records."""
+    export_transformer_items(
+        items=iter_gfd_stac_items(input_path),
+        source_slug="gfd",
+        provider=Provider(
+            name="Global Flood Database", roles=[ProviderRole.PRODUCER], url="https://global-flood-database.cloudtostreet.info/"
+        ),
+        output_dir=output_dir,
+    )
+
+
+def _gdacs_episode(path: Path, episode_type: str, hazard_type: str | None) -> GdacsEpisodes:
+    return GdacsEpisodes(
+        type=episode_type,
+        data=file_generic_data_source(path),
+        hazard_type=hazard_type,
+    )
+
+
+def _gdacs_data_source_from_manifest(manifest_path: Path) -> Any:
+    from pystac_monty.sources.gdacs import GDACSDataSource
+
+    base = manifest_path.parent
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    hazard_type = manifest.get("hazard_type")
+    source_url = manifest.get("source_url", manifest_path.as_uri())
+    event_path = base / manifest["event_data"]
+    episodes: list[tuple[GdacsEpisodes, GdacsEpisodes, GdacsEpisodes | None]] = []
+    for episode in manifest.get("episodes", []):
+        event = _gdacs_episode(base / episode["event"], _GDACS_EVENT, hazard_type)
+        geometry = _gdacs_episode(base / episode["geometry"], _GDACS_GEOMETRY, hazard_type)
+        impact_path = episode.get("impact")
+        impact = _gdacs_episode(base / impact_path, _GDACS_IMPACT, hazard_type) if impact_path else None
+        episodes.append((event, geometry, impact))
+    return GDACSDataSource(
+        data=GdacsDataSourceType(
+            source_url=source_url,
+            event_data=File(path=str(event_path.resolve()), data_type=DataType.FILE),
+            episodes=episodes,
+        )
+    )
+
+
+def iter_gdacs_stac_items(input_path: Path) -> list[Item]:
+    from pystac_monty.sources.gdacs import GDACSTransformer
+
+    data_source = _gdacs_data_source_from_manifest(input_path)
+    return collect_transformer_items(GDACSTransformer(data_source, default_batch_geocoder()))
+
+
+def convert_gdacs(input_path: Path, output_dir: Path) -> None:
+    """Export GDACS data. *input_path*: manifest JSON with relative ``event_data`` and ``episodes`` paths."""
+    export_transformer_items(
+        items=iter_gdacs_stac_items(input_path),
+        source_slug="gdacs",
+        provider=Provider(name="GDACS", roles=[ProviderRole.PRODUCER], url="https://www.gdacs.org/"),
+        output_dir=output_dir,
+    )
+
+
+BatchExportFn = Callable[[Path, Path], None]
+
+BATCH_EXPORTS: dict[str, BatchExportFn] = {
+    "glide": convert_glide,
+    "gfd": convert_gfd,
+    "gdacs": convert_gdacs,
+}
+
+
+def run_batch(name: str, input_path: Path, output_dir: Path) -> None:
+    BATCH_EXPORTS[name](input_path, output_dir)

--- a/pystac_monty/sources/batch_export.py
+++ b/pystac_monty/sources/batch_export.py
@@ -1,4 +1,12 @@
-"""Run existing Monty transformers and write static STAC via :mod:`pystac_monty.exporter`."""
+"""Run existing Monty transformers and write static STAC via :mod:`pystac_monty.exporter`.
+
+This is a thin developer harness for exercising a transformer over a local input file
+and writing the resulting static STAC. Source extraction/ingestion is owned by
+``montandon-etl``; keep this module simple and avoid re-implementing that logic here.
+Most sources expect a single native payload file; GDACS expects a pre-built
+:class:`~pystac_monty.sources.common.GdacsDataSourceType` bundle JSON (see
+:func:`load_gdacs_data_source_from_bundle`).
+"""
 
 from __future__ import annotations
 
@@ -21,16 +29,64 @@ from pystac_monty.sources.common import (
     MontyDataTransformer,
 )
 
-_GDACS_EVENT = "geteventdata"
-_GDACS_GEOMETRY = "getgeometry"
-_GDACS_IMPACT = "getimpact"
-
 
 def file_generic_data_source(input_path: Path, source_url: str | None = None) -> GenericDataSource:
     path = input_path.resolve()
     return GenericDataSource(
         source_url=source_url or path.as_uri(),
         input_data=File(path=str(path), data_type=DataType.FILE),
+    )
+
+
+def _resolve_file_path(path: str, base_dir: Path) -> str:
+    file_path = Path(path)
+    if file_path.is_absolute():
+        return str(file_path)
+    return str((base_dir / file_path).resolve())
+
+
+def _gdacs_file_input(path: str, base_dir: Path) -> File:
+    return File(path=_resolve_file_path(path, base_dir), data_type=DataType.FILE)
+
+
+def _gdacs_episode_from_dict(data: dict[str, Any], base_dir: Path) -> GdacsEpisodes:
+    input_data = data["data"]["input_data"]
+    return GdacsEpisodes(
+        type=data["type"],
+        hazard_type=data.get("hazard_type"),
+        data=GenericDataSource(
+            source_url=data["data"]["source_url"],
+            input_data=_gdacs_file_input(input_data["path"], base_dir),
+        ),
+    )
+
+
+def load_gdacs_data_source_from_bundle(bundle_path: Path) -> Any:
+    """Load a :class:`~pystac_monty.sources.gdacs.GDACSDataSource` from a bundle JSON file.
+
+    *bundle_path* must contain a serialized :class:`~pystac_monty.sources.common.GdacsDataSourceType`
+    document. Relative ``path`` values are resolved against the bundle directory.
+    Bundle assembly belongs in ``montandon-etl``; this loader only wires files into the transformer.
+    """
+    from pystac_monty.sources.gdacs import GDACSDataSource
+
+    base_dir = bundle_path.parent
+    raw = json.loads(bundle_path.read_text(encoding="utf-8"))
+    episodes: list[tuple[GdacsEpisodes, GdacsEpisodes, GdacsEpisodes | None]] = []
+    for episode_event, episode_geometry, episode_impact in raw["episodes"]:
+        episodes.append(
+            (
+                _gdacs_episode_from_dict(episode_event, base_dir),
+                _gdacs_episode_from_dict(episode_geometry, base_dir),
+                _gdacs_episode_from_dict(episode_impact, base_dir) if episode_impact is not None else None,
+            )
+        )
+    return GDACSDataSource(
+        data=GdacsDataSourceType(
+            source_url=raw["source_url"],
+            event_data=_gdacs_file_input(raw["event_data"]["path"], base_dir),
+            episodes=episodes,
+        )
     )
 
 
@@ -56,12 +112,12 @@ def export_transformer_items(
     source_slug: str,
     provider: Provider,
     output_dir: Path,
-    emit_empty_response_subcatalog: bool = False,
+    emit_empty_response_collection: bool = False,
 ) -> tuple[int, int, int, int]:
     config = BatchExportConfig(
         source_slug=source_slug,
         provider=provider,
-        emit_empty_response_subcatalog=emit_empty_response_subcatalog,
+        emit_empty_response_collection=emit_empty_response_collection,
     )
     counts = export_collected_items(config, items, output_dir)
     log_batch_role_counts(*counts)
@@ -104,47 +160,15 @@ def convert_gfd(input_path: Path, output_dir: Path) -> None:
     )
 
 
-def _gdacs_episode(path: Path, episode_type: str, hazard_type: str | None) -> GdacsEpisodes:
-    return GdacsEpisodes(
-        type=episode_type,
-        data=file_generic_data_source(path),
-        hazard_type=hazard_type,
-    )
-
-
-def _gdacs_data_source_from_manifest(manifest_path: Path) -> Any:
-    from pystac_monty.sources.gdacs import GDACSDataSource
-
-    base = manifest_path.parent
-    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-    hazard_type = manifest.get("hazard_type")
-    source_url = manifest.get("source_url", manifest_path.as_uri())
-    event_path = base / manifest["event_data"]
-    episodes: list[tuple[GdacsEpisodes, GdacsEpisodes, GdacsEpisodes | None]] = []
-    for episode in manifest.get("episodes", []):
-        event = _gdacs_episode(base / episode["event"], _GDACS_EVENT, hazard_type)
-        geometry = _gdacs_episode(base / episode["geometry"], _GDACS_GEOMETRY, hazard_type)
-        impact_path = episode.get("impact")
-        impact = _gdacs_episode(base / impact_path, _GDACS_IMPACT, hazard_type) if impact_path else None
-        episodes.append((event, geometry, impact))
-    return GDACSDataSource(
-        data=GdacsDataSourceType(
-            source_url=source_url,
-            event_data=File(path=str(event_path.resolve()), data_type=DataType.FILE),
-            episodes=episodes,
-        )
-    )
-
-
 def iter_gdacs_stac_items(input_path: Path) -> list[Item]:
     from pystac_monty.sources.gdacs import GDACSTransformer
 
-    data_source = _gdacs_data_source_from_manifest(input_path)
+    data_source = load_gdacs_data_source_from_bundle(input_path)
     return collect_transformer_items(GDACSTransformer(data_source, default_batch_geocoder()))
 
 
 def convert_gdacs(input_path: Path, output_dir: Path) -> None:
-    """Export GDACS data. *input_path*: manifest JSON with relative ``event_data`` and ``episodes`` paths."""
+    """Export GDACS data. *input_path*: ``GdacsDataSourceType`` bundle JSON with relative file paths."""
     export_transformer_items(
         items=iter_gdacs_stac_items(input_path),
         source_slug="gdacs",

--- a/tests/data-files/gdacs/fl-1102983-bundle.json
+++ b/tests/data-files/gdacs/fl-1102983-bundle.json
@@ -1,0 +1,59 @@
+{
+  "source_url": "https://github.com/IFRCGo/monty-stac-extension/raw/refs/heads/main/docs/model/sources/GDACS/1102983-1-geteventdata-source.json",
+  "event_data": {
+    "path": "1102983-1-geteventdata-source.json",
+    "data_type": "file"
+  },
+  "episodes": [
+    [
+      {
+        "type": "geteventdata",
+        "hazard_type": "FL",
+        "data": {
+          "source_url": "https://www.gdacs.org/gdacsapi/api/events/getepisodedata?eventtype=FL&eventid=1102983&episodeid=1",
+          "input_data": {
+            "path": "fl-1102983-ep1-event.json",
+            "data_type": "file"
+          }
+        }
+      },
+      {
+        "type": "getgeometry",
+        "hazard_type": "FL",
+        "data": {
+          "source_url": "https://www.gdacs.org/gdacsapi/api/polygons/getgeometry?eventtype=FL&eventid=1102983&episodeid=1",
+          "input_data": {
+            "path": "fl-1102983-ep1-geometry.json",
+            "data_type": "file"
+          }
+        }
+      },
+      null
+    ],
+    [
+      {
+        "type": "geteventdata",
+        "hazard_type": "FL",
+        "data": {
+          "source_url": "https://www.gdacs.org/gdacsapi/api/events/getepisodedata?eventtype=FL&eventid=1102983&episodeid=2",
+          "input_data": {
+            "path": "fl-1102983-ep2-event.json",
+            "data_type": "file"
+          }
+        }
+      },
+      {
+        "type": "getgeometry",
+        "hazard_type": "FL",
+        "data": {
+          "source_url": "https://www.gdacs.org/gdacsapi/api/polygons/getgeometry?eventtype=FL&eventid=1102983&episodeid=2",
+          "input_data": {
+            "path": "fl-1102983-ep2-geometry.json",
+            "data_type": "file"
+          }
+        }
+      },
+      null
+    ]
+  ]
+}

--- a/tests/data-files/glide/spain-flood.json
+++ b/tests/data-files/glide/spain-flood.json
@@ -1,0 +1,28 @@
+{
+  "glideset": [
+    {
+      "comments": "Glide test comments",
+      "year": 2024,
+      "docid": 23388,
+      "latitude": 38.6013316868745,
+      "homeless": 0,
+      "source": "GDACS",
+      "idsource": "",
+      "killed": 0,
+      "affected": 0,
+      "duration": 8,
+      "number": "2024-000199",
+      "injured": 0,
+      "month": 10,
+      "geocode": "ESP",
+      "location": "Spain",
+      "magnitude": "0",
+      "time": "",
+      "id": "",
+      "event": "FL",
+      "day": 27,
+      "status": "A",
+      "longitude": -3.41102534556838
+    }
+  ]
+}

--- a/tests/test_batch_export.py
+++ b/tests/test_batch_export.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from tests.conftest import get_data_file
 
 
-def test_convert_glide_writes_role_subcatalogs(tmp_path: Path) -> None:
+def test_convert_glide_writes_role_collections(tmp_path: Path) -> None:
     from pystac_monty.sources.batch_export import convert_glide
 
     convert_glide(Path(get_data_file("glide/spain-flood.json")), tmp_path)
@@ -22,6 +22,16 @@ def test_cli_lists_registered_sources() -> None:
     from pystac_monty.sources.batch_export import BATCH_EXPORTS
 
     assert {"glide", "gfd", "gdacs"}.issubset(BATCH_EXPORTS)
+
+
+def test_convert_gdacs_writes_role_collections(tmp_path: Path) -> None:
+    from pystac_monty.sources.batch_export import convert_gdacs
+
+    convert_gdacs(Path(get_data_file("gdacs/fl-1102983-bundle.json")), tmp_path)
+    assert (tmp_path / "gdacs-events" / "gdacs-events.json").is_file()
+    assert (tmp_path / "gdacs-hazards" / "gdacs-hazards.json").is_file()
+    events = list((tmp_path / "gdacs-events").glob("gdacs-event-*.json"))
+    assert events
 
 
 def test_run_batch_glide(tmp_path: Path) -> None:

--- a/tests/test_batch_export.py
+++ b/tests/test_batch_export.py
@@ -1,0 +1,32 @@
+"""Integration tests for batch export of existing transformers."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from tests.conftest import get_data_file
+
+
+def test_convert_glide_writes_role_subcatalogs(tmp_path: Path) -> None:
+    from pystac_monty.sources.batch_export import convert_glide
+
+    convert_glide(Path(get_data_file("glide/spain-flood.json")), tmp_path)
+    assert (tmp_path / "glide-events" / "glide-events.json").is_file()
+    assert (tmp_path / "glide-hazards" / "glide-hazards.json").is_file()
+    events = list((tmp_path / "glide-events").glob("glide-event-*.json"))
+    assert events
+
+
+def test_cli_lists_registered_sources() -> None:
+    from pystac_monty.sources.batch_export import BATCH_EXPORTS
+
+    assert {"glide", "gfd", "gdacs"}.issubset(BATCH_EXPORTS)
+
+
+def test_run_batch_glide(tmp_path: Path) -> None:
+    from pystac_monty.sources.batch_export import run_batch
+
+    run_batch("glide", Path(get_data_file("glide/spain-flood.json")), tmp_path)
+    collection = json.loads((tmp_path / "glide-events" / "glide-events.json").read_text(encoding="utf-8"))
+    assert collection["id"] == "glide-events"

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -1,0 +1,274 @@
+"""Tests for static Monty STAC export."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pystac
+import pytest
+from pystac import Item
+from pystac.provider import Provider, ProviderRole
+
+from pystac_monty.exporter import (
+    MONTY_STAC_EXAMPLES_BASE_URL,
+    BatchExportConfig,
+    MontySubcatalog,
+    build_empty_static_source_collection,
+    export_collected_items,
+    export_monty_subcatalog,
+    extent_for_monty_static_collection,
+    log_batch_role_counts,
+    partition_monty_source_items,
+    summaries_for_monty_static_collection,
+)
+from pystac_monty.extension import SCHEMA_URI, MontyExtension
+from pystac_monty.sources.batch_export import BATCH_EXPORTS, run_batch
+
+_PROVIDER = Provider(name="test", roles=[ProviderRole.PRODUCER])
+_GEOM = [(0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (0.0, 1.0), (0.0, 0.0)]
+_BBOX = [0.0, 0.0, 1.0, 1.0]
+_WHEN = datetime(2021, 1, 1, tzinfo=timezone.utc)
+
+
+def _source_item(item_id: str, role: str) -> Item:
+    item = Item(
+        id=item_id,
+        geometry=_GEOM,
+        bbox=_BBOX,
+        datetime=_WHEN,
+        properties={
+            "roles": ["source", role],
+            "monty:country_codes": ["ESP"],
+            "monty:hazard_codes": ["HM-FLOOD"],
+            "keywords": [role],
+        },
+    )
+    MontyExtension.add_to(item)
+    return item
+
+
+def test_is_source_response() -> None:
+    item = _source_item("response-1", "response")
+    assert MontyExtension.ext(item).is_source_response()
+
+
+def test_partition_monty_source_items() -> None:
+    items = [
+        _source_item("event-1", "event"),
+        _source_item("hazard-1", "hazard"),
+        _source_item("impact-1", "impact"),
+        _source_item("response-1", "response"),
+    ]
+    events, hazards, impacts, responses = partition_monty_source_items(items)
+    assert [item.id for item in events] == ["event-1"]
+    assert [item.id for item in hazards] == ["hazard-1"]
+    assert [item.id for item in impacts] == ["impact-1"]
+    assert [item.id for item in responses] == ["response-1"]
+
+
+def test_extent_for_empty_collection_uses_world_extent() -> None:
+    extent = extent_for_monty_static_collection([])
+    assert extent.spatial.bboxes == [[-180.0, -90.0, 180.0, 90.0]]
+
+
+def test_summaries_for_monty_static_collection_sorts_arrays() -> None:
+    item = _source_item("event-1", "event")
+    item.properties["monty:country_codes"] = ["DEU", "ESP"]
+    summaries = summaries_for_monty_static_collection([item], "event")
+    assert summaries.get_list("roles") == ["event", "source"]
+    assert summaries.get_list("monty:country_codes") == ["DEU", "ESP"]
+
+
+def test_build_empty_static_source_collection_omits_monty_extension() -> None:
+    collection = build_empty_static_source_collection(
+        collection_id="demo-response",
+        title="Demo response",
+        description="Empty response collection",
+        role="response",
+        provider=_PROVIDER,
+    )
+    assert collection.stac_extensions == []
+    assert collection.extra_fields["roles"] == ["response", "source"]
+
+
+def test_export_monty_subcatalog_writes_collection_and_items(tmp_path: Path) -> None:
+    items = [_source_item("event-1", "event"), _source_item("event-2", "event")]
+    export_monty_subcatalog(
+        MontySubcatalog(
+            out_dir=tmp_path / "demo-events",
+            collection_id="demo-events",
+            title="Demo events",
+            description="Demo source events",
+            role="event",
+            items=items,
+            provider=_PROVIDER,
+        )
+    )
+    collection_path = tmp_path / "demo-events" / "demo-events.json"
+    assert collection_path.is_file()
+    collection_doc = json.loads(collection_path.read_text(encoding="utf-8"))
+    assert collection_doc["id"] == "demo-events"
+    assert collection_doc["stac_extensions"] == [SCHEMA_URI]
+    assert collection_doc["summaries"]["roles"] == ["event", "source"]
+    assert {link["rel"] for link in collection_doc["links"]} >= {"self", "item"}
+
+    for item in items:
+        item_path = tmp_path / "demo-events" / f"{item.id}.json"
+        item_doc = json.loads(item_path.read_text(encoding="utf-8"))
+        assert item_doc["id"] == item.id
+        assert item_doc["collection"] == "demo-events"
+        assert not any(link["rel"] in {"parent", "root", "collection"} for link in item_doc.get("links", []))
+
+
+def test_export_collected_items_partitions_by_role(tmp_path: Path) -> None:
+    items = [
+        _source_item("event-1", "event"),
+        _source_item("hazard-1", "hazard"),
+        _source_item("impact-1", "impact"),
+    ]
+    config = BatchExportConfig(source_slug="demo", provider=_PROVIDER)
+    counts = export_collected_items(config, items, tmp_path)
+    assert counts == (1, 1, 1, 0)
+    assert (tmp_path / "demo-events" / "demo-events.json").is_file()
+    assert (tmp_path / "demo-hazards" / "demo-hazards.json").is_file()
+    assert (tmp_path / "demo-impacts" / "demo-impacts.json").is_file()
+    assert not (tmp_path / "demo-response").exists()
+
+
+def test_export_collected_items_emits_empty_response_subcatalog(tmp_path: Path) -> None:
+    items = [_source_item("event-1", "event")]
+    config = BatchExportConfig(
+        source_slug="demo",
+        provider=_PROVIDER,
+        emit_empty_response_subcatalog=True,
+    )
+    counts = export_collected_items(config, items, tmp_path)
+    assert counts == (1, 0, 0, 0)
+    response_collection = tmp_path / "demo-response" / "demo-response.json"
+    assert response_collection.is_file()
+    response_doc = json.loads(response_collection.read_text(encoding="utf-8"))
+    assert response_doc["stac_extensions"] == []
+    assert response_doc["summaries"]["roles"] == ["response", "source"]
+
+
+def test_extent_for_items_without_bbox_uses_world_spatial_extent() -> None:
+    item = _source_item("event-1", "event")
+    item.bbox = None
+    extent = extent_for_monty_static_collection([item])
+    assert extent.spatial.bboxes == [[-180.0, -90.0, 180.0, 90.0]]
+
+
+def test_extent_for_non_finite_bbox_uses_world_extent() -> None:
+    item = _source_item("event-1", "event")
+    item.bbox = [float("nan"), 0.0, 1.0, 1.0]
+    extent = extent_for_monty_static_collection([item])
+    assert extent.spatial.bboxes == [[-180.0, -90.0, 180.0, 90.0]]
+
+
+def test_summaries_datetime_from_item_properties() -> None:
+    item = _source_item("event-1", "event")
+    item.datetime = None
+    item.properties["start_datetime"] = "2021-01-01T00:00:00Z"
+    item.properties["end_datetime"] = "2021-01-02T00:00:00Z"
+    item.properties["datetime"] = "2021-01-01T12:00:00Z"
+    summaries = summaries_for_monty_static_collection([item], "event")
+    datetime_summary = summaries.get_range("datetime")
+    assert datetime_summary is not None
+    assert datetime_summary.minimum == "2021-01-01T12:00:00Z"
+
+
+def test_partition_ignores_items_without_source_role() -> None:
+    item = Item(
+        id="reference-1",
+        geometry=_GEOM,
+        bbox=_BBOX,
+        datetime=_WHEN,
+        properties={"roles": ["reference", "event"]},
+    )
+    MontyExtension.add_to(item)
+    assert partition_monty_source_items([item]) == ([], [], [], [])
+
+
+def test_export_published_example_layout(tmp_path: Path) -> None:
+    """Published examples: absolute self/collection hrefs, keywords outside summaries."""
+    item = _source_item("event-1", "event")
+    item.add_link(pystac.Link(rel="related", target="../demo-hazards/hazard-1.json"))
+    collection_id = "demo-events"
+    export_monty_subcatalog(
+        MontySubcatalog(
+            out_dir=tmp_path / collection_id,
+            collection_id=collection_id,
+            title="Demo events",
+            description="Demo source events",
+            role="event",
+            items=[item],
+            provider=_PROVIDER,
+            omit_keywords_from_summaries=True,
+            public_href_base=MONTY_STAC_EXAMPLES_BASE_URL,
+        )
+    )
+    base = MONTY_STAC_EXAMPLES_BASE_URL
+    collection_doc = json.loads((tmp_path / collection_id / f"{collection_id}.json").read_text(encoding="utf-8"))
+    item_doc = json.loads((tmp_path / collection_id / "event-1.json").read_text(encoding="utf-8"))
+
+    assert collection_doc["keywords"] == ["event"]
+    assert "keywords" not in collection_doc["summaries"]
+    assert collection_doc["links"] == [
+        {"rel": "item", "href": "./event-1.json", "type": "application/json"},
+        {"rel": "self", "href": f"{base}/{collection_id}/{collection_id}.json", "type": "application/json"},
+    ]
+
+    item_links = {link["rel"]: link["href"] for link in item_doc["links"]}
+    assert item_links["related"] == "../demo-hazards/hazard-1.json"
+    assert item_links["self"] == f"{base}/{collection_id}/event-1.json"
+    assert item_links["collection"] == f"{base}/{collection_id}/{collection_id}.json"
+
+
+def test_export_without_preserve_transformer_links(tmp_path: Path) -> None:
+    item = _source_item("event-1", "event")
+    item.add_link(pystac.Link(rel="related", target="./event-2.json"))
+    export_monty_subcatalog(
+        MontySubcatalog(
+            out_dir=tmp_path / "demo-events",
+            collection_id="demo-events",
+            title="Demo events",
+            description="Demo source events",
+            role="event",
+            items=[item],
+            provider=_PROVIDER,
+            preserve_transformer_item_links=False,
+        )
+    )
+    item_doc = json.loads((tmp_path / "demo-events" / "event-1.json").read_text(encoding="utf-8"))
+    assert [link["rel"] for link in item_doc.get("links", [])] == ["self"]
+
+
+def test_export_collected_items_writes_response_items(tmp_path: Path) -> None:
+    items = [_source_item("response-1", "response")]
+    counts = export_collected_items(BatchExportConfig(source_slug="demo", provider=_PROVIDER), items, tmp_path)
+    assert counts == (0, 0, 0, 1)
+    assert (tmp_path / "demo-response" / "demo-response.json").is_file()
+
+
+def test_log_batch_role_counts(caplog: pytest.LogCaptureFixture) -> None:
+    caplog.set_level("INFO")
+    log_batch_role_counts(1, 2, 3, 4)
+    assert "Created 1 events, 2 hazards, 3 impacts, 4 response" in caplog.text
+
+
+def test_run_batch(tmp_path: Path) -> None:
+    seen: dict[str, Path] = {}
+
+    def _fake_export(input_path: Path, output_dir: Path) -> None:
+        seen["input"] = input_path
+        seen["output"] = output_dir
+
+    BATCH_EXPORTS["demo"] = _fake_export
+    try:
+        run_batch("demo", tmp_path / "in", tmp_path / "out")
+    finally:
+        BATCH_EXPORTS.pop("demo", None)
+    assert seen["input"] == tmp_path / "in"
+    assert seen["output"] == tmp_path / "out"

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -14,10 +14,10 @@ from pystac.provider import Provider, ProviderRole
 from pystac_monty.exporter import (
     MONTY_STAC_EXAMPLES_BASE_URL,
     BatchExportConfig,
-    MontySubcatalog,
+    MontyCollectionSpec,
     build_empty_static_source_collection,
     export_collected_items,
-    export_monty_subcatalog,
+    export_monty_collection,
     extent_for_monty_static_collection,
     log_batch_role_counts,
     partition_monty_source_items,
@@ -93,10 +93,10 @@ def test_build_empty_static_source_collection_omits_monty_extension() -> None:
     assert collection.extra_fields["roles"] == ["response", "source"]
 
 
-def test_export_monty_subcatalog_writes_collection_and_items(tmp_path: Path) -> None:
+def test_export_monty_collection_writes_collection_and_items(tmp_path: Path) -> None:
     items = [_source_item("event-1", "event"), _source_item("event-2", "event")]
-    export_monty_subcatalog(
-        MontySubcatalog(
+    export_monty_collection(
+        MontyCollectionSpec(
             out_dir=tmp_path / "demo-events",
             collection_id="demo-events",
             title="Demo events",
@@ -137,12 +137,12 @@ def test_export_collected_items_partitions_by_role(tmp_path: Path) -> None:
     assert not (tmp_path / "demo-response").exists()
 
 
-def test_export_collected_items_emits_empty_response_subcatalog(tmp_path: Path) -> None:
+def test_export_collected_items_emits_empty_response_collection(tmp_path: Path) -> None:
     items = [_source_item("event-1", "event")]
     config = BatchExportConfig(
         source_slug="demo",
         provider=_PROVIDER,
-        emit_empty_response_subcatalog=True,
+        emit_empty_response_collection=True,
     )
     counts = export_collected_items(config, items, tmp_path)
     assert counts == (1, 0, 0, 0)
@@ -196,8 +196,8 @@ def test_export_published_example_layout(tmp_path: Path) -> None:
     item = _source_item("event-1", "event")
     item.add_link(pystac.Link(rel="related", target="../demo-hazards/hazard-1.json"))
     collection_id = "demo-events"
-    export_monty_subcatalog(
-        MontySubcatalog(
+    export_monty_collection(
+        MontyCollectionSpec(
             out_dir=tmp_path / collection_id,
             collection_id=collection_id,
             title="Demo events",
@@ -229,8 +229,8 @@ def test_export_published_example_layout(tmp_path: Path) -> None:
 def test_export_without_preserve_transformer_links(tmp_path: Path) -> None:
     item = _source_item("event-1", "event")
     item.add_link(pystac.Link(rel="related", target="./event-2.json"))
-    export_monty_subcatalog(
-        MontySubcatalog(
+    export_monty_collection(
+        MontyCollectionSpec(
             out_dir=tmp_path / "demo-events",
             collection_id="demo-events",
             title="Demo events",


### PR DESCRIPTION
Adds static on-disk export for Monty STAC and a CLI to run it against existing transformers.

- **`pystac_monty/exporter.py`**: partition items by Monty role (`event` / `hazard` / `impact` / `response`), build collections with summaries/extents, and write `{slug}-events|hazards|impacts|response` subcatalogs. Preserves transformer `related` links; strips catalog hierarchy links from exported items.
- **`pystac-monty` CLI** (`pyproject.toml` entry point): `pystac-monty <source> -i <input> -o <output>`.
- **`pystac_monty/sources/batch_export.py`**: wires up **glide**, **gfd**, and **gdacs** (GDACS uses a manifest JSON with relative episode paths). Registers sources in `BATCH_EXPORTS`. Uses local `monty-stac-extension/examples` when available.
- **`ItemMontyExtension.is_source_response()`** for response-role partitioning.

## Notes

- Batch export currently uses `MockGeocoder` (same as most transformer tests); production use may need a real geocoder.
- Other sources: add `convert_<name>` and register it in `BATCH_EXPORTS` in `batch_export.py`. Input shape varies by source (single JSON vs manifest).