### PR TITLE
fix(USGS): try resolve the country using the geocoder or from the losses

### DIFF
--- a/pystac_monty/geocoding.py
+++ b/pystac_monty/geocoding.py
@@ -200,7 +200,7 @@ class WorldAdministrativeBoundariesGeocoder(MontyGeoCoder):
         return None
 
     def get_iso3_from_point(self, point: Point) -> Optional[str]:
-        self.get_iso3_from_geometry(point.__geo_interface__)
+        return self.get_iso3_from_geometry(point.__geo_interface__)
 
     def get_geometry_from_admin_units(self, admin_units: str, simplified: bool = False) -> Optional[Dict[str, Any]]:
         raise NotImplementedError("Method not implemented")

--- a/pystac_monty/sources/usgs.py
+++ b/pystac_monty/sources/usgs.py
@@ -715,6 +715,7 @@ class USGSTransformer(MontyDataTransformer[USGSDataSource]):
         impact_item.set_collection(self.get_impact_collection())
 
         impact_item.properties["forecasted"] = True
+        impact_item.properties["roles"] = ["source", "impact"]
 
         monty.impact_detail = ImpactDetail(
             category=category, type=imp_type, value=value, unit=unit, estimate_type=MontyEstimateType.MODELLED

--- a/pystac_monty/sources/usgs.py
+++ b/pystac_monty/sources/usgs.py
@@ -382,6 +382,30 @@ class USGSTransformer(MontyDataTransformer[USGSDataSource]):
         # Fallback: iso2 is returned in case mapping not found.
         return iso_mappings.get(iso2.upper(), iso2)
 
+    def _get_primary_country_from_losses(self, losspager_items: typing.List[EmpiricalValidator] | None) -> typing.Optional[str]:
+        """Derive the most-affected country's ISO3 code from PAGER fatality estimates.
+
+        Used as a fallback when point-based reverse geocoding of the epicenter fails,
+        e.g. because the epicenter falls just offshore of the affected country.
+        """
+        if not losspager_items:
+            return None
+
+        fatalities_by_country: dict[str, int] = {}
+        for loss_data in losspager_items:
+            if not loss_data.empirical_fatality:
+                continue
+            for country in loss_data.empirical_fatality.country_fatalities:
+                fatalities_by_country[country.country_code] = (
+                    fatalities_by_country.get(country.country_code, 0) + country.fatalities
+                )
+
+        if not fatalities_by_country or max(fatalities_by_country.values()) == 0:
+            return None
+        # Use the max affected country
+        primary_iso2 = max(fatalities_by_country, key=fatalities_by_country.get)
+        return self.iso2_to_iso3(primary_iso2)
+
     def get_stac_items(self) -> typing.Generator[Item, None, None]:
         """Creates the STAC Items"""
         self.transform_summary.mark_as_started()
@@ -409,10 +433,10 @@ class USGSTransformer(MontyDataTransformer[USGSDataSource]):
                 return validated_alert_data
 
             validated_item = USGSValidator(**item_data)
+            losspager_validated_items = get_validated_data(losspager_data)
+            alert_validated_items = get_validated_alert_data(alert_data)
 
-            if event_item := self.make_source_event_item(item_data=validated_item):
-                losspager_validated_items = get_validated_data(losspager_data)
-                alert_validated_items = get_validated_alert_data(alert_data)
+            if event_item := self.make_source_event_item(item_data=validated_item, losspager_items=losspager_validated_items):
                 hazard_item = self.make_hazard_event_item(event_item=event_item, data_item=validated_item)
                 impact_items = self.make_impact_items(
                     event_item=event_item,
@@ -440,7 +464,9 @@ class USGSTransformer(MontyDataTransformer[USGSDataSource]):
     def make_items(self) -> typing.List[Item]:
         return list(self.get_stac_items())
 
-    def make_source_event_item(self, item_data: USGSValidator) -> Item:
+    def make_source_event_item(
+        self, item_data: USGSValidator, losspager_items: typing.List[EmpiricalValidator] | None = None
+    ) -> Item:
         """Create source event item from USGS data."""
 
         # Create geometry from coordinates
@@ -480,8 +506,15 @@ class USGSTransformer(MontyDataTransformer[USGSDataSource]):
         monty.episode_number = 1
         monty.hazard_codes = ["GH0101", "nat-geo-ear-gro", "EQ"]
 
-        # TODO Get country code from event data or geometry
-        iso3 = self.geocoder.get_iso3_from_point(point) or "UNK"
+        iso3 = self.geocoder.get_iso3_from_point(point) or self._get_primary_country_from_losses(losspager_items)
+        if not iso3:
+            logger.warning(
+                "Could not resolve a country code for USGS event %s at (lon=%s, lat=%s); falling back to 'UNK'",
+                item_data.id,
+                longitude,
+                latitude,
+            )
+            iso3 = "UNK"
         country_codes = [iso3]
 
         monty.country_codes = country_codes

--- a/tests/data/usgs/venezuela_alerts.json
+++ b/tests/data/usgs/venezuela_alerts.json
@@ -1,0 +1,58 @@
+[
+    {
+        "fatality": {
+            "type": "fatality",
+            "units": "fatalities",
+            "gvalue": 3.5,
+            "summary": false,
+            "level": "orange",
+            "bins": [
+                {
+                    "color": "yellow",
+                    "min": 1,
+                    "max": 10,
+                    "probability": 0.3
+                },
+                {
+                    "color": "orange",
+                    "min": 10,
+                    "max": 100,
+                    "probability": 0.5
+                },
+                {
+                    "color": "red",
+                    "min": 100,
+                    "max": 1000,
+                    "probability": 0.2
+                }
+            ]
+        },
+        "economic": {
+            "type": "economic",
+            "units": "USD",
+            "gvalue": 2.1,
+            "summary": false,
+            "level": "yellow",
+            "bins": [
+                {
+                    "color": "green",
+                    "min": 0,
+                    "max": 1000000,
+                    "probability": 0.4
+                },
+                {
+                    "color": "yellow",
+                    "min": 1000000,
+                    "max": 10000000,
+                    "probability": 0.4
+                },
+                {
+                    "color": "orange",
+                    "min": 10000000,
+                    "max": 100000000,
+                    "probability": 0.2
+                }
+            ]
+        }
+    }
+]

--- a/tests/data/usgs/venezuela_details.json
+++ b/tests/data/usgs/venezuela_details.json
@@ -1,0 +1,36 @@
+{
+    "type": "Feature",
+    "properties": {
+        "mag": 7.5,
+        "place": "20 km ESE of Yumare, Venezuela",
+        "time": 1782338711743,
+        "felt": 771,
+        "status": "reviewed",
+        "tsunami": 0,
+        "magType": "mww",
+        "title": "M 7.5 - 20 km ESE of Yumare, Venezuela",
+        "products": {
+            "shakemap": [
+                {
+                    "properties": {
+                        "depth": "10.0",
+                        "maximum-latitude": "14.533",
+                        "maximum-longitude": "-62.583",
+                        "minimum-latitude": "6.383",
+                        "minimum-longitude": "-72.583"
+                    },
+                    "contents": {
+                        "download/pin-thumbnail.png": {
+                            "url": "https://earthquake.usgs.gov/pdl/products/urn:usgs-product:us:shakemap:us6000t7zp:1783916348611/contents/download/pin-thumbnail.png"
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    "geometry": {
+        "type": "Point",
+        "coordinates": [-68.5036, 10.5086, 10]
+    },
+    "id": "us6000t7zp"
+}

--- a/tests/data/usgs/venezuela_losses.json
+++ b/tests/data/usgs/venezuela_losses.json
@@ -1,0 +1,46 @@
+[
+    {
+        "empirical_fatality": {
+            "total_fatalities": 53704,
+            "country_fatalities": [
+                {
+                    "country_code": "CO",
+                    "fatalities": 0
+                },
+                {
+                    "country_code": "AW",
+                    "fatalities": 0
+                },
+                {
+                    "country_code": "BQ",
+                    "fatalities": 0
+                },
+                {
+                    "country_code": "VE",
+                    "fatalities": 53704
+                }
+            ]
+        },
+        "empirical_economic": {
+            "total_dollars": 55230193960,
+            "country_dollars": [
+                {
+                    "country_code": "CO",
+                    "us_dollars": 0
+                },
+                {
+                    "country_code": "AW",
+                    "us_dollars": 0
+                },
+                {
+                    "country_code": "BQ",
+                    "us_dollars": 0
+                },
+                {
+                    "country_code": "VE",
+                    "us_dollars": 55230193960
+                }
+            ]
+        }
+    }
+]

--- a/tests/extensions/test_usgs.py
+++ b/tests/extensions/test_usgs.py
@@ -64,6 +64,13 @@ tibetan_plateau_eq = (
     "./tests/data/usgs/losses.json",  # Losses File
 )
 
+# Test on Venezuela data (event id=us6000t7zp)
+venezuela_eq = (
+    "venezuela_eq",  # Scenario name
+    "./tests/data/usgs/venezuela_details.json",  # Event File
+    "./tests/data/usgs/venezuela_losses.json",  # Losses File
+)
+
 
 class USGSTest(unittest.TestCase):
     """Test suite for USGS transformation functionality"""
@@ -244,6 +251,47 @@ class USGSTest(unittest.TestCase):
 
         self.assertTrue(found_event)
         self.assertTrue(found_hazard)
+
+    def test_event_hazard_impact_country_codes_are_consistent(self) -> None:
+        """Regression test for https://github.com/IFRCGo/pystac-monty/issues/167
+
+        The event and hazard items must resolve a real ISO3 country code for the
+        epicenter (not fall back to the non-spec "UNK" placeholder), and that code
+        must be consistent with the countries impact items derive from PAGER losses.
+        """
+        data_source = USGSDataSource(
+            data=USGSDataSourceType(
+                source_url=venezuela_eq[1],
+                event_data=File(path=venezuela_eq[1], data_type=DataType.FILE),
+                loss_data=File(path=venezuela_eq[2], data_type=DataType.FILE),
+            )
+        )
+        transformer = USGSTransformer(data_source, geocoder)
+
+        source_event_item = None
+        source_hazard_item = None
+        impact_items = []
+        for item in transformer.get_stac_items():
+            item.validate(validator=self.validator)
+            monty_item_ext = MontyExtension.ext(item)
+            if monty_item_ext.is_source_event():
+                source_event_item = item
+            elif monty_item_ext.is_source_hazard():
+                source_hazard_item = item
+            elif monty_item_ext.is_source_impact():
+                impact_items.append(item)
+
+        self.assertIsNotNone(source_event_item)
+        self.assertIsNotNone(source_hazard_item)
+        self.assertTrue(impact_items)
+
+        event_country_codes = MontyExtension.ext(source_event_item).country_codes
+        hazard_country_codes = MontyExtension.ext(source_hazard_item).country_codes
+
+        self.assertEqual(event_country_codes, ["VEN"])
+        self.assertEqual(hazard_country_codes, ["VEN"])
+        for impact_item in impact_items:
+            self.assertEqual(MontyExtension.ext(impact_item).country_codes, ["VEN"])
 
     # def test_invalid_event_data(self) -> None:
     #     """Test handling of invalid event data

--- a/tests/extensions/test_usgs.py
+++ b/tests/extensions/test_usgs.py
@@ -293,6 +293,35 @@ class USGSTest(unittest.TestCase):
         for impact_item in impact_items:
             self.assertEqual(MontyExtension.ext(impact_item).country_codes, ["VEN"])
 
+    def test_alert_derived_impact_items_have_correct_roles_and_country(self) -> None:
+        """Regression test for alerts"""
+        data_source = USGSDataSource(
+            data=USGSDataSourceType(
+                source_url=venezuela_eq[1],
+                event_data=File(path=venezuela_eq[1], data_type=DataType.FILE),
+                alerts_data=File(path="./tests/data/usgs/venezuela_alerts.json", data_type=DataType.FILE),
+            )
+        )
+        transformer = USGSTransformer(data_source, geocoder)
+
+        impact_items = []
+        for item in transformer.get_stac_items():
+            item.validate(validator=self.validator)
+            monty_item_ext = MontyExtension.ext(item)
+            if monty_item_ext.is_source_impact():
+                impact_items.append(item)
+
+        # One alert-derived impact item each for fatality and economic estimates
+        self.assertEqual(len(impact_items), 2)
+
+        for impact_item in impact_items:
+            self.assertEqual(impact_item.properties["roles"], ["source", "impact"])
+            self.assertNotIn("event", impact_item.properties["roles"])
+
+            country_codes = MontyExtension.ext(impact_item).country_codes
+            self.assertEqual(country_codes, ["VEN"])
+            self.assertNotIn("UNK", impact_item.id)
+
     # def test_invalid_event_data(self) -> None:
     #     """Test handling of invalid event data
 


### PR DESCRIPTION
Addresses the Issue #167 

- Try to resolve the country name using the Geocoder
- if the geocoder fails, get the country name from the Losses information (when multiple countries are affected, use the country that is affected heavily (max fatalities) as earthquake could have gone somewhere nearby.
- If still the country can't be resolved, use "UNK" and logs it.
- Test case updated


@emmanuelmathot  Please kindly review

cc @subinasr 

Note: Let's merge #178 into this PR first.