### PR TITLE
Fix/usgs alert impact item

### DIFF
--- a/pystac_monty/sources/usgs.py
+++ b/pystac_monty/sources/usgs.py
@@ -715,6 +715,7 @@ class USGSTransformer(MontyDataTransformer[USGSDataSource]):
         impact_item.set_collection(self.get_impact_collection())
 
         impact_item.properties["forecasted"] = True
+        impact_item.properties["roles"] = ["source", "impact"]
 
         monty.impact_detail = ImpactDetail(
             category=category, type=imp_type, value=value, unit=unit, estimate_type=MontyEstimateType.MODELLED

--- a/tests/data/usgs/venezuela_alerts.json
+++ b/tests/data/usgs/venezuela_alerts.json
@@ -1,0 +1,58 @@
+[
+    {
+        "fatality": {
+            "type": "fatality",
+            "units": "fatalities",
+            "gvalue": 3.5,
+            "summary": false,
+            "level": "orange",
+            "bins": [
+                {
+                    "color": "yellow",
+                    "min": 1,
+                    "max": 10,
+                    "probability": 0.3
+                },
+                {
+                    "color": "orange",
+                    "min": 10,
+                    "max": 100,
+                    "probability": 0.5
+                },
+                {
+                    "color": "red",
+                    "min": 100,
+                    "max": 1000,
+                    "probability": 0.2
+                }
+            ]
+        },
+        "economic": {
+            "type": "economic",
+            "units": "USD",
+            "gvalue": 2.1,
+            "summary": false,
+            "level": "yellow",
+            "bins": [
+                {
+                    "color": "green",
+                    "min": 0,
+                    "max": 1000000,
+                    "probability": 0.4
+                },
+                {
+                    "color": "yellow",
+                    "min": 1000000,
+                    "max": 10000000,
+                    "probability": 0.4
+                },
+                {
+                    "color": "orange",
+                    "min": 10000000,
+                    "max": 100000000,
+                    "probability": 0.2
+                }
+            ]
+        }
+    }
+]

--- a/tests/extensions/test_usgs.py
+++ b/tests/extensions/test_usgs.py
@@ -293,6 +293,35 @@ class USGSTest(unittest.TestCase):
         for impact_item in impact_items:
             self.assertEqual(MontyExtension.ext(impact_item).country_codes, ["VEN"])
 
+    def test_alert_derived_impact_items_have_correct_roles_and_country(self) -> None:
+        """Regression test for alerts"""
+        data_source = USGSDataSource(
+            data=USGSDataSourceType(
+                source_url=venezuela_eq[1],
+                event_data=File(path=venezuela_eq[1], data_type=DataType.FILE),
+                alerts_data=File(path="./tests/data/usgs/venezuela_alerts.json", data_type=DataType.FILE),
+            )
+        )
+        transformer = USGSTransformer(data_source, geocoder)
+
+        impact_items = []
+        for item in transformer.get_stac_items():
+            item.validate(validator=self.validator)
+            monty_item_ext = MontyExtension.ext(item)
+            if monty_item_ext.is_source_impact():
+                impact_items.append(item)
+
+        # One alert-derived impact item each for fatality and economic estimates
+        self.assertEqual(len(impact_items), 2)
+
+        for impact_item in impact_items:
+            self.assertEqual(impact_item.properties["roles"], ["source", "impact"])
+            self.assertNotIn("event", impact_item.properties["roles"])
+
+            country_codes = MontyExtension.ext(impact_item).country_codes
+            self.assertEqual(country_codes, ["VEN"])
+            self.assertNotIn("UNK", impact_item.id)
+
     # def test_invalid_event_data(self) -> None:
     #     """Test handling of invalid event data
 


### PR DESCRIPTION
Addresses the issue #169 

- Add the missing roles in the alerts item
- Update the test case
- The alerts data do not have the country information so it is inherited from the event item (e.g. https://earthquake.usgs.gov/product/losspager/us6000t7zp/us/1783916550513/json/alerts.json)