### PR TITLE
Add func to compute hash for extraction data

### DIFF
--- a/pystac_monty/sources/charter.py
+++ b/pystac_monty/sources/charter.py
@@ -79,6 +79,21 @@ MANUAL_REVIEW_DISASTER_TYPES = {
     "storm_hurricane_urban",
 }
 
+
+def compute_file_hash(content: bytes) -> str:
+    """Hash Charter JSON after stripping volatile properties."""
+    try:
+        data = json.loads(content)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return hashlib.sha256(content).hexdigest()
+    if isinstance(data, dict):
+        props = data.get("properties")
+        if isinstance(props, dict):
+            data = {**data, "properties": {k: v for k, v in props.items() if k not in CHARTER_VOLATILE_PROPERTIES}}
+    normalized = json.dumps(data, sort_keys=True, ensure_ascii=False).encode()
+    return hashlib.sha256(normalized).hexdigest()
+
+
 # CPE status to estimate_type (interim mapping)
 CPE_STATUS_MAPPING = {
     "notificationNew": "primary",
@@ -105,6 +120,11 @@ _INTERNAL_CHARTER_PROPS = {
     "cpe:processing_monitoring_id",
     "cpe:notification_source",
 }
+
+# Fields in GeoJSON `properties` that change on every source touch but carry no
+# meaningful data — excluded from the semantic hash so extraction doesn't re-transform
+# when only an administrative timestamp or internal Charter field changed.
+CHARTER_VOLATILE_PROPERTIES: frozenset[str] = frozenset({"updated", "created"} | _INTERNAL_CHARTER_PROPS)
 
 _CHARTER_PROVIDER = Provider(
     "International Charter Space and Major Disasters",

--- a/tests/extensions/test_charter.py
+++ b/tests/extensions/test_charter.py
@@ -16,6 +16,7 @@ from pystac_monty.sources.charter import (
     CHARTER_HAZARD_CODES,
     CharterDataSource,
     CharterTransformer,
+    compute_file_hash,
     convert_charter_activations,
     iter_charter_stac_items,
 )
@@ -786,3 +787,11 @@ class CharterTest(unittest.TestCase):
                         }
                     )
                 )
+
+    def test_compute_file_hash_stable_across_updated_only_diff(self) -> None:
+        props = {"title": "Flood", "disaster:type": ["flood"]}
+
+        content_old = json.dumps({"type": "Feature", "properties": {**props, "updated": "2024-01-01T00:00:00Z"}}).encode()
+        content_new = json.dumps({"type": "Feature", "properties": {**props, "updated": "2024-06-15T12:00:00Z"}}).encode()
+
+        self.assertEqual(compute_file_hash(content_old), compute_file_hash(content_new))


### PR DESCRIPTION
## Description
This func was initially added into montandon etl repo for computing hash for charter extraction data. This can cause issue in future if ignored fields in charter transformer are updated. Thus, this func is added towards transformer side.