### PR TITLE
Add workflow to auto-add issues/PRs to IFRCGo project board

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,16 @@
+name: Add to project
+
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened]
+
+jobs:
+  add-to-project:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v2.0.0
+        with:
+          project-url: https://github.com/orgs/IFRCGo/projects/28
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}


### PR DESCRIPTION
## Summary
- New GitHub Actions workflow (`.github/workflows/add-to-project.yml`) that adds every new issue and PR opened in this repo to https://github.com/orgs/IFRCGo/projects/28
- Uses `actions/add-to-project@v2.0.0`, pinned to the latest release
- Same setup as developmentseed/montandon-skills#21, developmentseed/montandon-website#20, IFRCGo/monty-stac-extension#119, developmentseed/esa-montandon#46

## Requires (not part of this PR)
- A repo secret named `ADD_TO_PROJECT_PAT` — a classic PAT with the `project` scope

## Test plan
- [ ] Add the `ADD_TO_PROJECT_PAT` secret to this repo
- [ ] Open a test issue/PR and confirm it appears on the project board