### PR TITLE
fix(pdc): add hazard mapping for HIGHWIND

### DIFF
--- a/pystac_monty/sources/pdc.py
+++ b/pystac_monty/sources/pdc.py
@@ -276,6 +276,7 @@ class PDCTransformer(MontyDataTransformer):
             "VOLCANO": ["GH0201", "nat-geo-vol-vol", "VO"],
             "WILDFIRE": ["EN0205", "nat-cli-wil-wil", "WF"],
             "WINTERSTORM": ["MH0403", "nat-met-sto-bli", "OT"],
+            "HIGHWIND": ["MH0301", "nat-met-sto-sto", "VW"],
         }
 
         # Geopolitical & Technological Hazards

--- a/tests/extensions/test_pdc.py
+++ b/tests/extensions/test_pdc.py
@@ -153,6 +153,7 @@ class PDCTest(unittest.TestCase):
         assert transformer._map_pdc_to_hazard_codes("EARTHQUAKE") == ["GH0101", "nat-geo-ear-gro", "EQ"]
         assert transformer._map_pdc_to_hazard_codes("TSUNAMI") == ["MH0705", "nat-geo-ear-tsu", "TS"]
         assert transformer._map_pdc_to_hazard_codes("WILDFIRE") == ["EN0205", "nat-cli-wil-wil", "WF"]
+        assert transformer._map_pdc_to_hazard_codes("HIGHWIND") == ["MH0301", "nat-met-sto-sto", "VW"]
 
     @parameterized.expand(load_scenarios(scenarios))
     def test_pdc_tech_social_hazard_codes_2025(self, transformer: PDCTransformer):


### PR DESCRIPTION
Addresses the issues #196 and sync with https://github.com/IFRCGo/monty-stac-extension/pull/123
- Add the hazard mapping for `HIGHWIND`
- Update the test case for `HIGHWIND` assertion.